### PR TITLE
fix: symbolic links to sam2.1

### DIFF
--- a/sam2/sam2_hiera_b+.yaml
+++ b/sam2/sam2_hiera_b+.yaml
@@ -1,1 +1,1 @@
-configs/sam2/sam2_hiera_b+.yaml
+configs/sam2.1/sam2.1_hiera_b+.yaml

--- a/sam2/sam2_hiera_l.yaml
+++ b/sam2/sam2_hiera_l.yaml
@@ -1,1 +1,1 @@
-configs/sam2/sam2_hiera_l.yaml
+configs/sam2.1/sam2.1_hiera_l.yaml

--- a/sam2/sam2_hiera_s.yaml
+++ b/sam2/sam2_hiera_s.yaml
@@ -1,1 +1,1 @@
-configs/sam2/sam2_hiera_s.yaml
+configs/sam2.1/sam2.1_hiera_s.yaml

--- a/sam2/sam2_hiera_t.yaml
+++ b/sam2/sam2_hiera_t.yaml
@@ -1,1 +1,1 @@
-configs/sam2/sam2_hiera_t.yaml
+configs/sam2.1/sam2.1_hiera_t.yaml


### PR DESCRIPTION
This fixes the symbolic links for the model configuration as mentioned [here](https://github.com/facebookresearch/sam2/issues/348).

This will fix the symbolic links for SAM2.1 when installing SAM2 using `pip`.