### PR TITLE
[demo] add GPU specification in `docker-compose.yaml` for the SAM 2 interactive webdemo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,3 +33,10 @@ services:
       - VIDEO_ENCODE_MAX_WIDTH=1280
       - VIDEO_ENCODE_MAX_HEIGHT=720
       - VIDEO_ENCODE_VERBOSE=False
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
This small PR adds GPU specification in `docker-compose.yaml` for the SAM 2 interactive webdemo, following https://docs.docker.com/compose/how-tos/gpu-support/#example-of-a-compose-file-for-running-a-service-with-access-to-1-gpu-device. It fixes a GPU access error as reported in https://github.com/facebookresearch/sam2/issues/354.

(close https://github.com/facebookresearch/sam2/issues/354)