### PR TITLE
[sam2][demo][1/x] Fix file upload

### DIFF
--- a/demo/backend/server/app.py
+++ b/demo/backend/server/app.py
@@ -128,6 +128,10 @@ app.add_url_rule(
         # https://strawberry.rocks/docs/operations/deployment
         # https://strawberry.rocks/docs/integrations/flask
         allow_queries_via_get=False,
+        # Strawberry recently changed multipart request handling, which now
+        # requires enabling support explicitly for views.
+        # https://github.com/strawberry-graphql/strawberry/issues/3655
+        multipart_uploads_enabled=True,
     ),
 )
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRA_PACKAGES = {
         "gunicorn>=23.0.0",
         "imagesize>=1.4.1",
         "pycocotools>=2.0.8",
-        "strawberry-graphql>=0.239.2",
+        "strawberry-graphql>=0.243.0",
     ],
     "dev": [
         "black==24.2.0",


### PR DESCRIPTION

Summary:

The Strawberry GraphQL library recently disabled multipart requests by default. This resulted in a video upload request returning "Unsupported content type" instead of uploading the video, processing it, and returning the video path.

This issue was raised in #361. A forward fix is to add `multipart_uploads_enabled=True` to the endpoint view.

Test Plan:

Tested locally with cURL and upload succeeds

*Request*

```
curl http://localhost:7263/graphql \
  -F operations='{ "query": "mutation($file: Upload!){ uploadVideo(file: $file) { path } }", "variables": { "file": null } }' \
  -F map='{ "file": ["variables.file"] }' \
  -F file=@video.mov
```

*Response*

```
{"data": {"uploadVideo": {"path": "uploads/<HASH>.mp4"}}}
```
