### PR TITLE
Fix training video loading bug

### DIFF
--- a/training/dataset/vos_raw_dataset.py
+++ b/training/dataset/vos_raw_dataset.py
@@ -78,7 +78,7 @@ class PNGRawDataset(VOSRawDataset):
             with g_pathmgr.open(file_list_txt, "r") as f:
                 subset = [os.path.splitext(line.strip())[0] for line in f]
         else:
-            subset = os.listdir(self.img_folder)
+            subset = [folder for folder in os.listdir(self.img_folder) if os.path.isdir(os.path.join(self.img_folder, folder))]
 
         # Read and process excluded files if provided
         if excluded_videos_list_txt is not None:

--- a/training/dataset/vos_segment_loader.py
+++ b/training/dataset/vos_segment_loader.py
@@ -110,7 +110,7 @@ class PalettisedPNGSegmentLoader:
         # build a mapping from frame id to their PNG mask path
         # note that in some datasets, the PNG paths could have more
         # than 5 digits, e.g. "00000000.png" instead of "00000.png"
-        png_filenames = os.listdir(self.video_png_root)
+        png_filenames = [filename for filename in os.listdir(self.video_png_root) if os.path.splitext(filename)[0].isdigit()]
         self.frame_id_to_png_filename = {}
         for filename in png_filenames:
             frame_id, _ = os.path.splitext(filename)


### PR DESCRIPTION
After downloading the original MOSE, the training directory of MOSE itself contains some hidden files. The changes ensures loading the correct files.