### PR TITLE
Modify the Dice loss

### DIFF
--- a/training/loss_fns.py
+++ b/training/loss_fns.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 
 import torch
 import torch.distributed
+import torch.linalg as LA
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -20,6 +21,9 @@ from training.utils.distributed import get_world_size, is_dist_avail_and_initial
 def dice_loss(inputs, targets, num_objects, loss_on_multimask=False):
     """
     Compute the DICE loss, similar to generalized IOU for masks
+    Reference:
+        Dice Semimetric Losses: Optimizing the Dice Score with Soft Labels.
+                Wang, Z. et. al. MICCAI 2023.
     Args:
         inputs: A float tensor of arbitrary shape.
                 The predictions for each example.
@@ -38,11 +42,11 @@ def dice_loss(inputs, targets, num_objects, loss_on_multimask=False):
         # flatten spatial dimension while keeping multimask channel dimension
         inputs = inputs.flatten(2)
         targets = targets.flatten(2)
-        numerator = 2 * (inputs * targets).sum(-1)
     else:
         inputs = inputs.flatten(1)
-        numerator = 2 * (inputs * targets).sum(1)
     denominator = inputs.sum(-1) + targets.sum(-1)
+    difference = LA.vector_norm(inputs - targets, ord=1, dim=-1)
+    numerator = (denominator - difference) / 2
     loss = 1 - (numerator + 1) / (denominator + 1)
     if loss_on_multimask:
         return loss / num_objects


### PR DESCRIPTION
The Dice loss in `training.loss_fns` is modified based on [JDTLoss](https://github.com/zifuwanggg/JDTLosses/blob/master/losses/jdt_loss.py) and [segmentation_models.pytorch](https://github.com/qubvel-org/segmentation_models.pytorch/blob/main/segmentation_models_pytorch/losses/_functional.py).

The original loss functions are incompatible with soft labels. For example, with a ground truth value of 0.5 for a single pixel, the Dice loss is minimized when the predicted value is 1, which is clearly erroneous. To address this, the intersection term is rewritten as $\frac{\|x\|_1 + \|y\|_1 - \|x-y\|_1}{2}$. This reformulation has been proven to retain equivalence with the original versions when the ground truth is binary (i.e. one-hot hard labels), while resolving the issue with soft labels [1, 2].

Although the original SAM/SAM2 models were trained without soft labels, this modification enables soft label training for downstream fine-tuning without breaking the existing implementation.

PS: in the original [implementation](https://github.com/facebookresearch/sam2/blob/c98aa6bea377d5c000cdc80197ce402dbf5304dc/training/loss_fns.py#L43), `inputs` is flattened but `targets` is not. This seems uncommon.

### Example
```
import torch
import torch.linalg as LA
import torch.nn.functional as F

torch.manual_seed(0)

b, c, h, w = 4, 3, 32, 32
dims = (0, 2, 3)

pred = torch.rand(b, c, h, w).softmax(dim=1)
soft_label = torch.rand(b, c, h, w).softmax(dim=1)
hard_label = torch.randint(low=0, high=c, size=(b, h, w))
one_hot_label = F.one_hot(hard_label, c).permute(0, 3, 1, 2)

def dice_old(x, y, dims):
    cardinality = torch.sum(x, dim=dims) + torch.sum(y, dim=dims)
    intersection = torch.sum(x * y, dim=dims)
    return 2 * intersection / cardinality

def dice_new(x, y, dims):
    cardinality = torch.sum(x, dim=dims) + torch.sum(y, dim=dims)
    difference = LA.vector_norm(x - y, ord=1, dim=dims)
    intersection = (cardinality - difference) / 2
    return 2 * intersection / cardinality

print(dice_old(pred, one_hot_label, dims), dice_new(pred, one_hot_label, dims))
print(dice_old(pred, soft_label, dims), dice_new(pred, soft_label, dims))
print(dice_old(pred, pred, dims), dice_new(pred, pred, dims))

# tensor([0.3345, 0.3310, 0.3317]) tensor([0.3345, 0.3310, 0.3317])
# tensor([0.3321, 0.3333, 0.3350]) tensor([0.8680, 0.8690, 0.8700])
# tensor([0.3487, 0.3502, 0.3544]) tensor([1., 1., 1.])
```

### References
[1] Dice Semimetric Losses: Optimizing the Dice Score with Soft Labels. Zifu Wang, Teodora Popordanoska, Jeroen Bertels, Robin Lemmens, Matthew B. Blaschko. *MICCAI 2023*.

[2] Jaccard Metric Losses: Optimizing the Jaccard Index with Soft Labels. Zifu Wang, Xuefei Ning, Matthew B. Blaschko. *NeurIPS 2023*.