### PR TITLE
[sam2][frame-loading] Add streaming frame loading on top of lazy loading

### DIFF
--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -46,15 +46,16 @@ class SAM2VideoPredictor(SAM2Base):
         video_path,
         offload_video_to_cpu=False,
         offload_state_to_cpu=False,
-        async_loading_frames=False,
+        frame_load_config=None,
     ):
         """Initialize an inference state."""
+        frame_load_config = frame_load_config or {}
         compute_device = self.device  # device of the model
         images, video_height, video_width = load_video_frames(
             video_path=video_path,
             image_size=self.image_size,
             offload_video_to_cpu=offload_video_to_cpu,
-            async_loading_frames=async_loading_frames,
+            frame_load_config=frame_load_config,
             compute_device=compute_device,
         )
         inference_state = {}

--- a/tools/vos_inference.py
+++ b/tools/vos_inference.py
@@ -135,7 +135,7 @@ def vos_inference(
     ]
     frame_names.sort(key=lambda p: int(os.path.splitext(p)[0]))
     inference_state = predictor.init_state(
-        video_path=video_dir, async_loading_frames=False
+        video_path=video_dir, frame_load_config=None
     )
     height = inference_state["video_height"]
     width = inference_state["video_width"]
@@ -273,7 +273,7 @@ def vos_separate_inference_per_object(
     ]
     frame_names.sort(key=lambda p: int(os.path.splitext(p)[0]))
     inference_state = predictor.init_state(
-        video_path=video_dir, async_loading_frames=False
+        video_path=video_dir, frame_load_config=None
     )
     height = inference_state["video_height"]
     width = inference_state["video_width"]


### PR DESCRIPTION
The AsyncVideoFrameLoader expects image paths to be available ahead of time but loads frames lazily. The Streaming loader does not assume that all inputs are available ahead of time but still loads frames lazily.

Refactored AsyncVideoFrameLoader into a LazyVideoFrameLoader class and extended 2 implementations that are: 1) lazy input + lazy load and 2) eager input + lazy load