### PR TITLE
fix demo video downloading: Add explicit DTS/CTS in video export

### DIFF
--- a/demo/frontend/src/common/codecs/VideoEncoder.ts
+++ b/demo/frontend/src/common/codecs/VideoEncoder.ts
@@ -32,6 +32,7 @@ export function encode(
     let encodedFrameIndex = 0;
     let nextKeyFrameTimestamp = 0;
     let trackID: number | null = null;
+    let totalDuration = 0;
     const durations: number[] = [];
 
     const outputFile = createFile();
@@ -52,9 +53,14 @@ export function encode(
         }
         const shiftedDuration = durations.shift();
         if (shiftedDuration != null) {
+          const scaledDuration = getScaledDuration(shiftedDuration);
+          totalDuration += scaledDuration;
+
           outputFile.addSample(trackID, uint8, {
-            duration: getScaledDuration(shiftedDuration),
-            is_sync: chunk.type === 'key',
+              duration: scaledDuration,
+              is_sync: chunk.type === 'key',
+              dts: totalDuration,  // Add explicit DTS
+              cts: totalDuration,  // Add explicit CTS
           });
           encodedFrameIndex++;
           progressCallback?.(encodedFrameIndex / numFrames);


### PR DESCRIPTION
See issues https://github.com/facebookresearch/sam2/issues/426 and https://github.com/facebookresearch/sam2/issues/404

On Linux, the downloaded files from the demo are corrupted and only show a single frame. This issue doesn't occur when using the demo from the [official website](https://sam2.metademolab.com/demo). I don't fully understand the issue but the change in this PR fixes it for me