### PR TITLE
Added support for pathlib Paths when loading videos

### DIFF
--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -6,6 +6,7 @@
 
 import os
 import warnings
+from pathlib import Path
 from threading import Thread
 
 import numpy as np
@@ -182,6 +183,8 @@ def load_video_frames(
     Load the video frames from video_path. The frames are resized to image_size as in
     the model and are loaded to GPU if offload_video_to_cpu=False. This is used by the demo.
     """
+    if isinstance(video_path, Path):
+        video_path = str(video_path)
     is_bytes = isinstance(video_path, bytes)
     is_str = isinstance(video_path, str)
     is_mp4_path = is_str and os.path.splitext(video_path)[-1] in [".mp4", ".MP4"]


### PR DESCRIPTION
When currently trying to load a video by passing a pathlib Path to init_state(...), the call fails with a NotImplementedError, stating the function is only implemented for jpeg folders / mp4 files - even if the path references such a folder file. As this is somewhat misleading, I added support for using Path objects to reference video files / folders.