### PR TITLE
Proceed building the demo image even when /opt/conda/bin/ffmpeg does not exist

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -32,7 +32,7 @@ RUN pip install --upgrade pip setuptools
 RUN pip install -e ".[interactive-demo]"
 
 # https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/issues/69#issuecomment-1826764707
-RUN rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg
+RUN rm -f /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg
 
 # Make app directory. This directory will host all files required for the
 # backend and SAM 2 inference files.


### PR DESCRIPTION
This patch fixes the following error found when I tried to build the Docker image of the SAM2 demo by running `docker compose up --build`:
```
 => [backend  6/15] RUN pip install -e ".[interactive-demo]"                                                                                                                                        14.2s 
 => ERROR [backend  7/15] RUN rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg                                                                                                    0.2s 
------                                                                                                                                                                                                    
 > [backend  7/15] RUN rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg:                                                                                                               
0.145 rm: cannot remove '/opt/conda/bin/ffmpeg': No such file or directory                                                                                                                                
------                                                                                                                                                                                                    
failed to solve: process "/bin/sh -c rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg" did not complete successfully: exit code: 1                                                     
```
