### PR TITLE
Fix Typo in sam2/build_sam.py: “sucessfully” to “successfully”

### DIFF
--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -171,4 +171,4 @@ def _load_checkpoint(model, ckpt_path):
         if unexpected_keys:
             logging.error(unexpected_keys)
             raise RuntimeError()
-        logging.info("Loaded checkpoint sucessfully")
+        logging.info("Loaded checkpoint successfully")


### PR DESCRIPTION
This pull request corrects a typo in the sam2/build_sam.py file, changing “sucessfully” to “successfully”. 