### PR TITLE
Update backend.Dockerfile: Forcing PyAV 13.1.0

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -30,6 +30,7 @@ COPY README.md .
 
 RUN pip install --upgrade pip setuptools
 RUN pip install -e ".[interactive-demo]"
+RUN pip uninstall -y av && pip install av==13.1.0
 
 # https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/issues/69#issuecomment-1826764707
 RUN rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg


### PR DESCRIPTION
PyAV removed support for side_data in v14, due to ffmpeg deprecation so we need to target v13.1.0 until an alternative solution becomes viable.