### PR TITLE
Demo (backend): pytorch 2.5.1 docker image does not have ffmpeg installed in conda env so no need to remove

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -32,7 +32,7 @@ RUN pip install --upgrade pip setuptools
 RUN pip install -e ".[interactive-demo]"
 
 # https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/issues/69#issuecomment-1826764707
-RUN rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg
+RUN ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg
 
 # Make app directory. This directory will host all files required for the
 # backend and SAM 2 inference files.


### PR DESCRIPTION
As mentioned in issue #548, `ffmpeg` is not installed in `pytorch/pytorch:2.5.1-cuda12.1-cudnn9-runtime`'s conda environment, so an attempt to remove it in [backend.Dockerfile](https://github.com/facebookresearch/sam2/blob/main/backend.Dockerfile) results in an error.

Fixes: #548 