### PR TITLE
fix: add workaround for mps inference

### DIFF
--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -239,6 +239,10 @@ class Attention(nn.Module):
         v = self._separate_heads(v, self.num_heads)
 
         dropout_p = self.dropout_p if self.training else 0.0
+        if q.dtype != k.dtype:
+            k = k.to(dtype=q.dtype)
+        if q.dtype != v.dtype:
+            v = v.to(dtype=q.dtype)
         # Attention
         out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
 
@@ -302,6 +306,10 @@ class RoPEAttention(Attention):
         )
 
         dropout_p = self.dropout_p if self.training else 0.0
+        if q.dtype != k.dtype:
+            k = k.to(dtype=q.dtype)
+        if q.dtype != v.dtype:
+            v = v.to(dtype=q.dtype)
         # Attention
         out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
 


### PR DESCRIPTION
```
File ~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/sam2_video_predictor.py:603, in SAM2VideoPredictor.propagate_in_video(self, inference_state, start_frame_idx, max_frame_num_to_track, reverse)
    [601](https://file+.vscode-resource.vscode-cdn.net/Users/daisuke/workspace/sam2/notebooks/~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/sam2_video_predictor.py:601) else:
    [602](https://file+.vscode-resource.vscode-cdn.net/Users/daisuke/workspace/sam2/notebooks/~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/sam2_video_predictor.py:602)     storage_key = "non_cond_frame_outputs"
--> [603](https://file+.vscode-resource.vscode-cdn.net/Users/daisuke/workspace/sam2/notebooks/~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/sam2_video_predictor.py:603)     current_out, pred_masks = self._run_single_frame_inference(
...
--> [314](https://file+.vscode-resource.vscode-cdn.net/Users/daisuke/workspace/sam2/notebooks/~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/modeling/sam/transformer.py:314) out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
    [316](https://file+.vscode-resource.vscode-cdn.net/Users/daisuke/workspace/sam2/notebooks/~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/modeling/sam/transformer.py:316) out = self._recombine_heads(out)
    [317](https://file+.vscode-resource.vscode-cdn.net/Users/daisuke/workspace/sam2/notebooks/~/workspace/sam2/.venv/lib/python3.12/site-packages/sam2/modeling/sam/transformer.py:317) out = self.out_proj(out)

RuntimeError: Expected query, key, and value to have the same dtype, but got query.dtype: float key.dtype: float and value.dtype: c10::BFloat16 instead.
```
When inferencing with mps, the error above occurs. 