### PR TITLE
Add support for BMP/PNG when loading image sequence from a folder

### DIFF
--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -262,7 +262,7 @@ def load_video_frames_from_images(
             "ffmpeg to start the JPEG file from 00000.jpg."
         )
     
-    supported_formats = set([".jpg", ".jpeg", ".png", "bmp"])
+    supported_formats = set([".jpg", ".jpeg", ".png", ".bmp"])
     frame_names = [
         p
         for p in os.listdir(img_folder)

--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -219,6 +219,9 @@ def load_video_frames_from_jpg_images(
     async_loading_frames=False,
     compute_device=torch.device("cuda"),
 ):
+    """
+    Alias for `load_video_frames_from_images()` for backward compatibility.
+    """
     return load_video_frames_from_images(
         video_path,
         image_size,


### PR DESCRIPTION
The current function for loading images from a folder only supports `jpeg`. This PR adds support for `png` and `bmp`.
- Solve issue #236
- This PR is similar to #183. However, this PR adds `bmp` as well and updates the function name to eliminate the inconsistency of its supported format while preserving the backward compatibility.