### PR TITLE
Fix rm ffmpeg not found in docker

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -32,7 +32,7 @@ RUN pip install --upgrade pip setuptools
 RUN pip install -e ".[interactive-demo]"
 
 # https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/issues/69#issuecomment-1826764707
-RUN rm /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg
+RUN rm -f /opt/conda/bin/ffmpeg && ln -s /bin/ffmpeg /opt/conda/bin/ffmpeg
 
 # Make app directory. This directory will host all files required for the
 # backend and SAM 2 inference files.


### PR DESCRIPTION
backend.Dockerfile fails at `RUN rm /opt/conda/bin/ffmpeg`, due to ffmpeg *somehow* missing from that path. `rm -f` fixes this.  

This closes [issue 584](https://github.com/facebookresearch/sam2/issues/584).