### PR TITLE
Fix PyAV compatibility issue with DISPLAYMATRIX access

### DIFF
--- a/demo/backend/server/data/transcoder.py
+++ b/demo/backend/server/data/transcoder.py
@@ -75,7 +75,11 @@ def get_video_metadata(path: str) -> VideoMetadata:
             assert video_stream.time_base is not None
 
             # for rotation, see: https://github.com/PyAV-Org/PyAV/pull/1249
-            rotation_deg = video_stream.side_data.get("DISPLAYMATRIX", 0)
+            try:
+                rotation_deg = video_stream.side_data.get("DISPLAYMATRIX", 0)
+            except AttributeError:
+                # Fallback for older PyAV versions or different video stream types
+                rotation_deg = 0
             num_video_frames = video_stream.frames
             video_start_time = float(video_stream.start_time * video_stream.time_base)
             width, height = video_stream.width, video_stream.height


### PR DESCRIPTION
## Summary
Fixes video upload error caused by missing `side_data` attribute in newer PyAV versions (resolves #497).

## Problem
Users cannot upload videos due to `AttributeError: 'VideoCodecContext' object has no attribute 'side_data'`. Current workaround requires downgrading PyAV to 13.1.0.

## Solution
Added error handling for `side_data` access in video metadata retrieval, providing fallback value when attribute is not available.

## Changes
- Added try-catch block in `get_video_metadata()` function
- Graceful fallback to rotation_deg = 0 when `side_data` is unavailable
- Maintains compatibility with both old and new PyAV versions

Fixes #497 