### PR TITLE
Make Hiera input channels and video normalization configurable

### DIFF
--- a/sam2/modeling/backbones/hieradet.py
+++ b/sam2/modeling/backbones/hieradet.py
@@ -173,6 +173,7 @@ class Hiera(nn.Module):
 
     def __init__(
         self,
+        in_chans: int = 3,
         embed_dim: int = 96,  # initial embed dim
         num_heads: int = 1,  # initial number of heads
         drop_path_rate: float = 0.0,  # stochastic depth
@@ -211,6 +212,7 @@ class Hiera(nn.Module):
         self.return_interm_layers = return_interm_layers
 
         self.patch_embed = PatchEmbed(
+            in_chans=in_chans,
             embed_dim=embed_dim,
         )
         # Which blocks have global att?

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -30,6 +30,8 @@ class SAM2VideoPredictor(SAM2Base):
         # if `add_all_frames_to_correct_as_cond` is True, we also append to the conditioning frame list any frame that receives a later correction click
         # if `add_all_frames_to_correct_as_cond` is False, we conditioning frame list to only use those initial conditioning frames
         add_all_frames_to_correct_as_cond=False,
+        img_mean=(0.485, 0.456, 0.406),
+        img_std=(0.229, 0.224, 0.225),
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -37,6 +39,8 @@ class SAM2VideoPredictor(SAM2Base):
         self.non_overlap_masks = non_overlap_masks
         self.clear_non_cond_mem_around_input = clear_non_cond_mem_around_input
         self.add_all_frames_to_correct_as_cond = add_all_frames_to_correct_as_cond
+        self.img_mean = img_mean
+        self.img_std = img_std
 
     @torch.inference_mode()
     def init_state(
@@ -52,6 +56,8 @@ class SAM2VideoPredictor(SAM2Base):
             video_path=video_path,
             image_size=self.image_size,
             offload_video_to_cpu=offload_video_to_cpu,
+            img_mean=self.img_mean,
+            img_std=self.img_std,
             async_loading_frames=async_loading_frames,
             compute_device=compute_device,
         )

--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -89,13 +89,16 @@ def mask_to_box(masks: torch.Tensor):
     return bbox_coords
 
 
-def _load_img_as_tensor(img_path, image_size):
+def _load_img_as_tensor(img_path, image_size, num_channels=3):
     img_pil = Image.open(img_path)
-    img_np = np.array(img_pil.convert("RGB").resize((image_size, image_size)))
+    pil_mode = "L" if num_channels == 1 else "RGB"
+    img_np = np.array(img_pil.convert(pil_mode).resize((image_size, image_size)))
     if img_np.dtype == np.uint8:  # np.uint8 is expected for JPEG images
         img_np = img_np / 255.0
     else:
         raise RuntimeError(f"Unknown image dtype: {img_np.dtype} on {img_path}")
+    if num_channels == 1:
+        img_np = img_np[:, :, None]  # (H, W) -> (H, W, 1)
     img = torch.from_numpy(img_np).permute(2, 0, 1)
     video_width, video_height = img_pil.size  # the original video size
     return img, video_height, video_width
@@ -152,8 +155,9 @@ class AsyncVideoFrameLoader:
         if img is not None:
             return img
 
+        num_channels = self.img_mean.shape[0]
         img, video_height, video_width = _load_img_as_tensor(
-            self.img_paths[index], self.image_size
+            self.img_paths[index], self.image_size, num_channels
         )
         self.video_height = video_height
         self.video_width = video_width
@@ -264,9 +268,10 @@ def load_video_frames_from_jpg_images(
         )
         return lazy_images, lazy_images.video_height, lazy_images.video_width
 
-    images = torch.zeros(num_frames, 3, image_size, image_size, dtype=torch.float32)
+    num_channels = img_mean.shape[0]  # img_mean is already a tensor here (line 253)
+    images = torch.zeros(num_frames, num_channels, image_size, image_size, dtype=torch.float32)
     for n, img_path in enumerate(tqdm(img_paths, desc="frame loading (JPEG)")):
-        images[n], video_height, video_width = _load_img_as_tensor(img_path, image_size)
+        images[n], video_height, video_width = _load_img_as_tensor(img_path, image_size, num_channels)
     if not offload_video_to_cpu:
         images = images.to(compute_device)
         img_mean = img_mean.to(compute_device)


### PR DESCRIPTION
## Summary
- All changes are backwards-compatible ΓÇö all new params default to their original values
- SAM2 is increasingly used in non-RGB domains (medical imaging, satellite, IR, depth); currently requires forking just to support grayscale/single-channel inputs
- Minimal changes: 3 files touched, 18 lines added, 5 removed

## Changes
- `hieradet.py`: Add `in_chans` param to `Hiera.__init__` (default=3), passed through to `PatchEmbed`
- `sam2_video_predictor.py`: Add `img_mean`/`img_std` params to `SAM2VideoPredictor.__init__`, forwarded to `load_video_frames`
- `misc.py`: `_load_img_as_tensor` now accepts `num_channels`; grayscale images loaded as `(H,W,1)`; hardcoded `3` in frame tensor allocation replaced with `num_channels`

## Usage example (grayscale)

Config YAML:
```yaml
model:
  _target_: sam2.modeling.sam2_base.SAM2Base
  image_encoder:
    _target_: sam2.modeling.backbones.image_encoder.ImageEncoder
    trunk:
      _target_: sam2.modeling.backbones.hieradet.Hiera
      in_chans: 1
```

Predictor instantiation:
```python
predictor = SAM2VideoPredictor(
    ...,
    img_mean=(0.5,),
    img_std=(0.5,),
)
```